### PR TITLE
moving the return false on aria-check later in the checkbox observer

### DIFF
--- a/javascript/mobile_questionnaire.js
+++ b/javascript/mobile_questionnaire.js
@@ -8,16 +8,16 @@ setTimeout(function() {
     var nextButton = document.getElementsByClassName('next-button');
     var allCheckboxes = document.getElementsByClassName('item item-block item-md item-checkbox');
     var allTextBoxes = document.getElementsByClassName('text-input text-input-md ng-star-inserted');
+    var pageNum = document.getElementsByClassName('pagenum-current');
+    pageNum = pageNum[0].innerHTML;
 
-    
     window.clicked_input = e => {
         checkIfFinalRequiredResponse(e);
     };
-    var checkboxes = document.getElementsByClassName('questionnaire-checkbox-checked');
+
+    var checkboxes = document.getElementsByClassName('questionnaire-checkbox-checked-' + pageNum );
     for(var i = 0; i < checkboxes.length; i++) {  
-        checkboxes[i].childNodes[0].className+= ' ' + 'checkbox-checked';
-        checkboxes[i].childNodes[1].setAttribute('aria-checked', true);
-        checkboxes[i].childNodes[0].setAttribute('aria-checked', true);
+        checkboxes[i].click();
     };
 
     //setting up observer for sliders that are completed and na applicable
@@ -219,16 +219,31 @@ function checkboxObserver(mutationList, observer) {
 
             var currentRequiredValue = mutation.target.parentElement.getAttribute('data-currentinput');
             var finalRequiredInput = mutation.target.parentElement.getAttribute('data-finalinput');
-            var checkedCheckboxes = document.getElementsByClassName('checkbox-icon checkbox-checked');
+            var pageNum = document.getElementsByClassName('pagenum-current');
+
+            pageNum = pageNum[pageNum.length - 1].innerHTML;
+
+            if(mutation.target.getAttribute('aria-checked') == 'false') {
+                if(mutation.target.parentElement.classList.contains('questionnaire-checkbox-checked-' + pageNum)) {
+                    mutation.target.parentElement.classList.remove('questionnaire-checkbox-checked-' + pageNum );
+                }
+                return;
+            } else {
+                if(mutation.target.parentElement.classList.contains('checkbox-md')) {
+                    mutation.target.parentElement.classList.add('questionnaire-checkbox-checked-' + pageNum );
+                }
+            }
 
             if(!currentRequiredValue || !finalRequiredInput) {
                 return;
             }
 
+            var checkedCheckboxes = document.getElementsByClassName('questionnaire-checkbox-checked-' + pageNum);
+
             if(!requiredInputs.includes(currentRequiredValue) && currentRequiredValue) {
                 requiredInputs.push(currentRequiredValue); //only push if it has not been added to the array already
-            } else if(mutation.target.parentElement.getAttribute('ng-reflect-model') == 'false' && currentRequiredValue) {
-                if( checkedCheckboxes.length < finalRequiredInput) {
+            } else if(mutation.target.parentElement.getAttribute('ng-reflect-model') == 'false') {
+                if( checkedCheckboxes.length <= 1) {
                     var index = requiredInputs.indexOf(currentRequiredValue);
                     if (index > -1) {
                         requiredInputs.splice(index, 1);
@@ -247,10 +262,6 @@ function checkboxObserver(mutationList, observer) {
                 for(var i = 0; i < nextButton.length; i++){
                     nextButton[i].disabled = true;
                 }
-            }
-
-            if(mutation.target.getAttribute('aria-checked') == 'false') {
-                return;
             }
 
             var numberOfRequiredAnswers = 0;

--- a/javascript/mobile_questionnaire.js
+++ b/javascript/mobile_questionnaire.js
@@ -217,10 +217,6 @@ function checkboxObserver(mutationList, observer) {
     switch(mutation.type) {
         case 'attributes':
 
-            if(mutation.target.getAttribute('aria-checked') == 'false') {
-                return;
-            }
-
             var currentRequiredValue = mutation.target.parentElement.getAttribute('data-currentinput');
             var finalRequiredInput = mutation.target.parentElement.getAttribute('data-finalinput');
             var checkedCheckboxes = document.getElementsByClassName('checkbox-icon checkbox-checked');
@@ -251,6 +247,10 @@ function checkboxObserver(mutationList, observer) {
                 for(var i = 0; i < nextButton.length; i++){
                     nextButton[i].disabled = true;
                 }
+            }
+
+            if(mutation.target.getAttribute('aria-checked') == 'false') {
+                return;
             }
 
             var numberOfRequiredAnswers = 0;

--- a/templates/mobile_view_activity_branching_page.mustache
+++ b/templates/mobile_view_activity_branching_page.mustache
@@ -77,7 +77,7 @@
                                 <ion-label><core-format-text text="<%content%>"></core-format-text></ion-label>
                                     <ion-checkbox [(ngModel)]="CONTENT_OTHERDATA.responses['response_<%info.type_id%>_<%info.id%>_<%id%>']" 
                                         <%#completed%>disabled="true"<%/completed%>
-                                        <%#value%>checked="true" class="questionnaire-checkbox-checked"<%/value%>
+                                        <%#value%>checked="true" class="questionnaire-checkbox-checked-<%pagenum%>"<%/value%>
                                         data-finalinput="<%info.current_required_resp%>"
                                         data-currentinput="<%info.final_required_resp%>"
                                     ></ion-checkbox>
@@ -197,6 +197,7 @@
                 <%/nextpage%>
             <%/completed%>
             <div class="hidden-submit-button-check-{{CONTENT_OTHERDATA.disable_save}}"></div>
+            <div class="pagenum-current" hidden><%pagenum%></div>
             </ion-list>
         </ion-card>
     </div>

--- a/templates/mobile_view_activity_page.mustache
+++ b/templates/mobile_view_activity_page.mustache
@@ -78,7 +78,7 @@
                                 <ion-label><core-format-text text="<%content%>"></core-format-text></ion-label>
                                     <ion-checkbox [(ngModel)]="CONTENT_OTHERDATA.responses['response_<%info.type_id%>_<%info.id%>_<%id%>']" 
                                         <%#completed%>disabled="true"<%/completed%>
-                                        <%#value%>checked="true" class="questionnaire-checkbox-checked"<%/value%>
+                                        <%#value%>checked="true" class="questionnaire-checkbox-checked-<%pagenum%>"<%/value%>
                                         data-finalinput="<%info.current_required_resp%>"
                                         data-currentinput="<%info.final_required_resp%>"
                                     ></ion-checkbox>
@@ -198,6 +198,7 @@
                 <%/nextpage%>
             <%/completed%>
             <div class="hidden-submit-button-check-{{CONTENT_OTHERDATA.disable_save}}"></div>
+            <div class="pagenum-current" hidden><%pagenum%></div>
             </ion-list>
         </ion-card>
     </div>


### PR DESCRIPTION
moving the return false on aria-check later in the checkbox observer

https://jira.2u.com/browse/CTED-288

* ran through it again, had to add a check for checkboxes on that page, but because of angular all of the checkboxes are built as one, so I need to check for that specific page
* based on that I add a class and remove it if it's clicked, I can then check to see if the checkboxes on that page are filled, if so we are fine, if not we disable the next-page button
* on load, click the checkbox to stop the double clicking problem